### PR TITLE
Fix OWOP in Safari

### DIFF
--- a/src/js/canvas_renderer.js
+++ b/src/js/canvas_renderer.js
@@ -320,8 +320,8 @@ function render(type) {
 			var cliph = clusterCanvasSize - clipy;
 			clipw = clipw + x < cwidth / zoom ? clipw : cwidth / zoom - x;
 			cliph = cliph + y < cheight / zoom ? cliph : cheight / zoom - y;
-			clipw = (clipw + 1) | 0; /* Math.ceil */
-			cliph = (cliph + 1) | 0;
+			//clipw = (clipw + 1) | 0; /* Math.ceil */
+			//cliph = (cliph + 1) | 0;
 			if (clipw > 0 && cliph > 0) {
 				ctx.drawImage(cluster.canvas, clipx, clipy, clipw, cliph, x, y, clipw, cliph);
 			}


### PR DESCRIPTION
When ctx.drawImage() clipping width and height are rounded, it leads to the clipping area going beyond the edge of the image in some cases. Chromium and Firefox handle this fine and just clip to the end of the image. Safari throws a fit and decides to cancel drawImage entirely, leaving large areas of the canvas blank and buggy.
This pull request removes that rounding, which should prevent that issue.
Floating point math isn't perfect, but Safari seems to have a small tolerance for these coordinates (about 0.000001 px in my testing) which is far greater than the inaccuracy of floating point math.

I'm unsure why this rounding was done to begin with, perhaps this change breaks something I'm not aware of?
