### PR TITLE
Correct pixel distance check so it aligns with the server

### DIFF
--- a/src/js/protocol/old.js
+++ b/src/js/protocol/old.js
@@ -396,10 +396,10 @@ class OldProtocolImpl extends Protocol {
 	}
 
 	updatePixel(x, y, rgb, undocb) {
-		var distx = Math.trunc(x / OldProtocol.chunkSize) - Math.trunc(this.lastSentX / (OldProtocol.chunkSize * 16)); distx *= distx;
-		var disty = Math.trunc(y / OldProtocol.chunkSize) - Math.trunc(this.lastSentY / (OldProtocol.chunkSize * 16)); disty *= disty;
+		var distx = Math.floor(x / OldProtocol.chunkSize) - Math.floor(this.lastSentX / (OldProtocol.chunkSize * 16)); distx *= distx;
+		var disty = Math.floor(y / OldProtocol.chunkSize) - Math.floor(this.lastSentY / (OldProtocol.chunkSize * 16)); disty *= disty;
 		var dist = Math.sqrt(distx + disty);
-		if (this.isConnected() && (dist < 3 || player.rank == RANK.ADMIN) && this.placeBucket.canSpend(1)) {
+		if (this.isConnected() && (dist < 4 || player.rank == RANK.ADMIN) && this.placeBucket.canSpend(1)) {
 			var array = new ArrayBuffer(11);
 			var dv = new DataView(array);
 			dv.setInt32(0,  x, true);


### PR DESCRIPTION
Currently, when protocol.updatePixel is called, the distance check between the cursor and pixel in the owop client is incorrect and doesn't line up with the server's check. See https://discord.com/channels/350296414720491530/374636146073796618/1116499269868847125

Math.trunc works differently for negative numbers and leads to incorrect distances. Math.floor is the correct way to calculate which chunk the cursor and pixel are in. Additionally, the threshold in the if condition should be `< 4`, not `< 3`, in order to line up with the server's math and flooring.