### PR TITLE
Fix client-server pixel desynchronization due to incorrectly handled rollbacks

### DIFF
--- a/src/js/protocol/old.js
+++ b/src/js/protocol/old.js
@@ -408,7 +408,11 @@ class OldProtocolImpl extends Protocol {
 			dv.setUint8(9, rgb[1]);
 			dv.setUint8(10, rgb[2]);
 			this.ws.send(array);
-			this.pendingEdits[`${x},${y}`] = setTimeout(undocb, 2000);
+			let key = `${x},${y}`;
+			if(this.pendingEdits[key]) {
+				clearTimeout(this.pendingEdits[key]);
+			}
+			this.pendingEdits[key] = setTimeout(undocb, 2000);
 			return true;
 		}
 		return false;

--- a/src/js/protocol/old.js
+++ b/src/js/protocol/old.js
@@ -409,7 +409,7 @@ class OldProtocolImpl extends Protocol {
 			dv.setUint8(10, rgb[2]);
 			this.ws.send(array);
 			let key = `${x},${y}`;
-			if(this.pendingEdits[key]) {
+			if (this.pendingEdits[key]) {
 				clearTimeout(this.pendingEdits[key]);
 			}
 			this.pendingEdits[key] = setTimeout(undocb, 2000);


### PR DESCRIPTION
The `updatePixel` method takes a callback parameter which is called to roll back the update if the server has not responded to confirm the updated pixel within 2 seconds. However, the implementation is flawed. This flaw only reveals itself when the server is experiencing intense-enough lag. Outline:
1. Assume that a pixel at coordinates `4,39` has the color value `128,128,128`.
2. `updatePixel` is called with the color `0,0,0` at coordinates `4,39`. It sends this update to the server, and sets a timeout to roll back the update if the server has not confirmed the update within 2 seconds. The timeout is stored under `this.pendingEdits["4,39"]` on the OldProtocol instance.
3. Server is experiencing intense lag, with delays of up to 5 seconds.
4. `updatePixel` is called again with the color `255,255,255` at coordinates `4,39`, before the server has confirmed the previous update. The method sets a timeout to roll back the new update if the server has not confirmed the update within 2 seconds. It is stored under `this.pendingEdits["4,39"]`, replacing the reference to the old timeout. However, the previous timeout still applies because it has not been cleared!
5. The server confirms both updates, and on the server-side, the pixel's color value is `255,255,255`. The client acknowledges this and clears the timeout stored under `this.pendingEdits["4,39"]`.
6. At some point, the old, dereferenced timeout fires the callback, which rolls back the pixel's color to its value before the first call to `updatePixel`.
7. The client now believes the color value for the pixel at coordinates `4,39` is `128,128,128`. According to the server, the actual color value is `255,255,255`.
8. The user will try to set the pixel to his intended color, `255,255,255`, but it will not work because the server believes the color is already `255,255,255`, which means there is nothing to update. Hence, the client and the server are desynchronized at this point.

To test and fix this bug, I modified [Lapis' server](https://github.com/lapishusky/owopserver) to create artificial lag. I have created a video demonstrating the behavior before and after this patch: https://files.catbox.moe/mq0msu.mp4

To fix this bug, I have made `updatePixel` check for an existing timeout before setting a new timeout. If a timeout exists for that coordinate, it is cleared.